### PR TITLE
Update blueprint to make it work with latest Brooklyn and Terraform version

### DIFF
--- a/catalog.bom
+++ b/catalog.bom
@@ -1,7 +1,7 @@
 brooklyn.catalog:
 
   id: terraform
-  version: 0.12.0-SNAPSHOT
+  version: 1.0.0-SNAPSHOT
 
   description: |
     Brooklyn Terraform entity for lifecycle management of a Terraform configuration
@@ -13,7 +13,7 @@ brooklyn.catalog:
     overview: README.md
 
   libraries:
-  - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.cloudsoft.terraform&a=brooklyn-terraform&v=0.12.0-SNAPSHOT&e=jar"
+  - "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.cloudsoft.terraform&a=brooklyn-terraform&v=1.0.0-SNAPSHOT&e=jar"
 
   itemType: entity
   item:

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>org.apache.brooklyn</groupId>
         <artifactId>brooklyn-downstream-parent</artifactId>
-        <version>0.12.0</version>  <!-- BROOKLYN_VERSION -->
+        <version>1.0.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
     </parent>
 
     <groupId>io.cloudsoft.terraform</groupId>
     <artifactId>brooklyn-terraform</artifactId>
     <!-- Update catalog.bom when changing the project's version. -->
-    <version>0.12.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Brooklyn Terraform</name>

--- a/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
@@ -103,8 +103,13 @@ public class TerraformSshDriver extends JavaSoftwareProcessSshDriver implements 
 
     @Override
     public void launch() {
+        List<String> commands = new LinkedList<String>();
+        commands.add(makeTerraformCommand("init -input=false"));
+        commands.add(makeTerraformCommand("plan -out=tfplan -input=false"));
+        commands.add(makeTerraformCommand("apply -no-color -input=false tfplan"));
+
         ScriptHelper helper = newScript(LAUNCHING)
-                .body.append(makeTerraformCommand("apply -no-color -input=false"))
+                .body.append(commands)
                 .failOnNonZeroResultCode(false)
                 .noExtraOutput()
                 .gatherOutput();


### PR DESCRIPTION
Otherwise, the bundle will not install because the version range is between `>=0.12.0 and <1.0.0`. It also updates the launch command to work with the latest CLI, as described here: https://learn.hashicorp.com/terraform/development/running-terraform-in-automation

Tested on latest Brooklyn and AMP, with the example blueprint given on the README

The `catalog.bom` will require the new version to be push to maven central to work. However I'm not sure how to do this.