### PR TITLE
Removing the condition for Vsphere provider to do plan and lightApply…

### DIFF
--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -38,7 +38,7 @@ public interface TerraformConfiguration extends SoftwareProcess {
     // Update reference.json when changing this value.
     @SetFromFlag("version")
     ConfigKey<String> SUGGESTED_VERSION = ConfigKeys
-            .newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.0.10");
+            .newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.0.11");
 
     @SetFromFlag("tfPollingPeriod")
     ConfigKey<Duration> POLLING_PERIOD = ConfigKeys.builder(Duration.class)

--- a/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
@@ -196,11 +196,8 @@ public class TerraformSshDriver extends AbstractSoftwareProcessSshDriver impleme
             LOG.debug("Terraform plan exists!!");
         } else {
             runApplyTask();
-            // workaround for vsphere
-            if (provider == PlanLogEntry.Provider.VSPHERE) {
-                runJsonPlanTask();
-                runLightApplyTask();
-            }
+            runJsonPlanTask();
+            runLightApplyTask();
         }
     }
 


### PR DESCRIPTION
… tasks, bumping tf version

It has been observed that sometimes with AWS the deployed configuration goes into drift state immediately, running these tasks helps to prevent it.

Also bumping up the tf version from 1.0.10 to 1.0.11