### PR TITLE
Deploy a resources defined inside a module

### DIFF
--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -70,6 +70,12 @@ public interface TerraformConfiguration extends SoftwareProcess {
             .description("URL of the file containing values for the Terraform variables.")
             .build();
 
+    @SetFromFlag("tfWorkingDirectory")
+    ConfigKey<String> WORKING_DIRECTORY = ConfigKeys.builder(String.class)
+            .name("tf.working.directory")
+            .description("Working directory for Terraform commands.")
+            .defaultValue("")
+            .build();
     AttributeSensor<String> CONFIGURATION_APPLIED = Sensors.newStringSensor("tf.configuration.applied",
             "The most recent time a Terraform configuration has been successfully applied.");
 

--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -76,6 +76,13 @@ public interface TerraformConfiguration extends SoftwareProcess {
             .description("Working directory for Terraform commands.")
             .defaultValue("")
             .build();
+
+    @SetFromFlag("tfModuleDepthState")
+    ConfigKey<Integer> MODULE_DEPTH = ConfigKeys.builder(Integer.class)
+            .name("tf.module.depth")
+            .description("Module depth to be represented.")
+            .defaultValue(1)
+            .build();
     AttributeSensor<String> CONFIGURATION_APPLIED = Sensors.newStringSensor("tf.configuration.applied",
             "The most recent time a Terraform configuration has been successfully applied.");
 

--- a/src/main/java/io/cloudsoft/terraform/TerraformDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformDriver.java
@@ -53,7 +53,7 @@ public interface TerraformDriver extends SoftwareProcessDriver {
     }
 
     default String makeTerraformCommand(String argument) {
-        return format("cd %s && %s/terraform %s", getRunDir(), getInstallDir(), argument);
+        return format("cd %s && %s/terraform %s", getEnvironmentDir(), getInstallDir(), argument);
     }
 
     default String getConfigurationFilePath() {
@@ -65,11 +65,11 @@ public interface TerraformDriver extends SoftwareProcessDriver {
     }
 
     default String getStateFilePath() {
-        return getRunDir() + "/terraform.tfstate";
+        return getEnvironmentDir() + "/terraform.tfstate";
     }
 
     // these are just here to allow the terraform commands building methods to be default too :)
     String getRunDir();
     String getInstallDir();
-
+    String getEnvironmentDir();
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
@@ -333,4 +333,28 @@ public class TerraformSshDriver extends AbstractSoftwareProcessSshDriver impleme
                 .newTask()
                 .asTask();
     }
+
+    @Override
+    public String getEnvironmentDir() {
+        String baseDir = super.getRunDir();
+        String workingDirectory = getWorkingDirectory();
+        return Strings.isEmpty(workingDirectory) ?
+                baseDir :
+                baseDir + "/" + workingDirectory;
+    }
+
+    public String getWorkingDirectory() {
+        String workingDir = entity.getConfig(TerraformConfiguration.WORKING_DIRECTORY);
+        return workingDir.startsWith("/") ?
+                removeInitialSlashes(workingDir) :
+                workingDir;
+    }
+
+    private String removeInitialSlashes(String workingDir) {
+        //todojd improve + test
+        while(workingDir.startsWith("/")){
+            workingDir = workingDir.substring(1);
+        }
+        return workingDir;
+    }
 }

--- a/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
@@ -79,7 +79,9 @@ public class TerraformSshDriver extends AbstractSoftwareProcessSshDriver impleme
         if (os == null) return "linux_amd64";
         // If not Mac, assume Linux
         String osType = os.isMac() ? "darwin" : "linux";
-        String archType = os.is64bit() ? "amd64" : "386";
+        String archType = os.is64bit() ?
+                os.getArch().toLowerCase().contains("arm") ? "arm64" : "amd64":
+                os.getArch().toLowerCase().contains("arm") ? "arm" : "386";
 
         return osType + "_" + archType;
     }

--- a/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformSshDriver.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 
 import static io.cloudsoft.terraform.TerraformConfiguration.TERRAFORM_DOWNLOAD_URL;
 import static java.lang.String.format;
@@ -74,14 +75,15 @@ public class TerraformSshDriver extends AbstractSoftwareProcessSshDriver impleme
     }
 
     public String getOsTag() {
+        final String ARM_ARCH_PATTERNS = "(arm|aarch)\\w*";
         OsDetails os = getLocation().getOsDetails();
         // If no details, assume 64-bit Linux
         if (os == null) return "linux_amd64";
         // If not Mac, assume Linux
         String osType = os.isMac() ? "darwin" : "linux";
         String archType = os.is64bit() ?
-                os.getArch().toLowerCase().contains("arm") ? "arm64" : "amd64":
-                os.getArch().toLowerCase().contains("arm") ? "arm" : "386";
+                Pattern.matches(ARM_ARCH_PATTERNS, os.getArch().toLowerCase()) ? "arm64" : "amd64":
+                Pattern.matches(ARM_ARCH_PATTERNS, os.getArch().toLowerCase()) ? "arm" : "386";
 
         return osType + "_" + archType;
     }

--- a/src/test/java/io/cloudsoft/terraform/TerraformJsonPlanParsingTest.java
+++ b/src/test/java/io/cloudsoft/terraform/TerraformJsonPlanParsingTest.java
@@ -289,4 +289,33 @@ public class TerraformJsonPlanParsingTest {
         assertEquals(resources.size(), 3);
         assertEquals(resources.stream().filter(m -> m.containsValue("create")).count(), 3);
     }
+
+    @Test
+    void testParsedStateWithModule() throws IOException {
+        String state = loadTestData("state/show-using-module.json");
+        Map<String, Object> result = StateParser.parseResources(state,0);
+        // Only one resource as root
+        assertEquals(result.size(),1);
+        // Nine resources reading the first level of modules
+        result = StateParser.parseResources(state,1);
+        assertEquals(result.size(),9);
+        // 21 resources reading the second level of modules
+        result = StateParser.parseResources(state,2);
+        assertEquals(result.size(),21);
+        // There is only two levels, passing more depth is ignored
+        result = StateParser.parseResources(state,10);
+        assertEquals(result.size(),21);
+    }
+
+    @Test
+    void testParsedStateWithoutModule() throws IOException {
+        String state = loadTestData("state/show-single-resource.json");
+        // If not depth is passed, defaults in 0
+        Map<String, Object> result = StateParser.parseResources(state);
+        assertEquals(result.size(),1);
+        result = StateParser.parseResources(state,1);
+        assertEquals(result.size(),1);
+        result = StateParser.parseResources(state,10);
+        assertEquals(result.size(),1);
+    }
 }

--- a/src/test/resources/state/show-single-resource.json
+++ b/src/test/resources/state/show-single-resource.json
@@ -1,0 +1,102 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.1.4",
+  "values": {
+    "outputs": {
+      "id": {
+        "sensitive": false,
+        "value": "sg-01484b93f40426a7f"
+      },
+      "name": {
+        "sensitive": false,
+        "value": "terraform-20220425083341393100000001"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_security_group.allow_all",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "allow_all",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "values": {
+            "arn": "arn:aws:ec2:eu-west-2:304295633295:security-group/sg-01484b93f40426a7f",
+            "description": "test-security-group allowing all access",
+            "egress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 0,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "-1",
+                "security_groups": [],
+                "self": false,
+                "to_port": 0
+              }
+            ],
+            "id": "sg-01484b93f40426a7f",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 0,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "-1",
+                "security_groups": [],
+                "self": false,
+                "to_port": 0
+              }
+            ],
+            "name": "terraform-20220425083341393100000001",
+            "name_prefix": "terraform-",
+            "owner_id": "304295633295",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "TestSG-KillMePlease"
+            },
+            "tags_all": {
+              "Name": "TestSG-KillMePlease",
+              "cloudsoft:group": "AMP",
+              "cloudsoft:workload": "Terraform",
+              "environment": "dev"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-619e7d08"
+          },
+          "sensitive_values": {
+            "egress": [
+              {
+                "cidr_blocks": [
+                  false
+                ],
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "security_groups": []
+              }
+            ],
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  false
+                ],
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "security_groups": []
+              }
+            ],
+            "tags": {},
+            "tags_all": {}
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/state/show-using-module.json
+++ b/src/test/resources/state/show-using-module.json
@@ -1,0 +1,1044 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.1.4",
+  "values": {
+    "outputs": {
+      "jumpbox_dns": {
+        "sensitive": false,
+        "value": "ec2-3-11-102-192.eu-west-2.compute.amazonaws.com"
+      },
+      "jumpbox_ip": {
+        "sensitive": false,
+        "value": "3.11.102.192"
+      },
+      "vpc_cidr": {
+        "sensitive": false,
+        "value": "172.1.0.0/16"
+      },
+      "vpc_private_subnets": {
+        "sensitive": false,
+        "value": [
+          "172.1.0.0/24"
+        ]
+      },
+      "vpc_public_subnets": {
+        "sensitive": false,
+        "value": [
+          "172.1.100.0/24"
+        ]
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "data.aws_availability_zones.available",
+          "mode": "data",
+          "type": "aws_availability_zones",
+          "name": "available",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "all_availability_zones": null,
+            "exclude_names": null,
+            "exclude_zone_ids": null,
+            "filter": null,
+            "group_names": [
+              "eu-west-2"
+            ],
+            "id": "eu-west-2",
+            "names": [
+              "eu-west-2a",
+              "eu-west-2b",
+              "eu-west-2c"
+            ],
+            "state": null,
+            "zone_ids": [
+              "euw2-az2",
+              "euw2-az3",
+              "euw2-az1"
+            ]
+          },
+          "sensitive_values": {
+            "group_names": [
+              false
+            ],
+            "names": [
+              false,
+              false,
+              false
+            ],
+            "zone_ids": [
+              false,
+              false,
+              false
+            ]
+          }
+        }
+      ],
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.test-one.aws_eip.jumpbox_elastic_ip",
+              "mode": "managed",
+              "type": "aws_eip",
+              "name": "jumpbox_elastic_ip",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 0,
+              "values": {
+                "address": null,
+                "allocation_id": "eipalloc-0be32257e30139158",
+                "associate_with_private_ip": null,
+                "association_id": "eipassoc-09268cfd447837a84",
+                "carrier_ip": "",
+                "customer_owned_ip": "",
+                "customer_owned_ipv4_pool": "",
+                "domain": "vpc",
+                "id": "eipalloc-0be32257e30139158",
+                "instance": "i-08930acac0730f52a",
+                "network_border_group": "eu-west-2",
+                "network_interface": "eni-02544bb6156703420",
+                "private_dns": "ip-172-1-100-64.eu-west-2.compute.internal",
+                "private_ip": "172.1.100.64",
+                "public_dns": "ec2-3-11-102-192.eu-west-2.compute.amazonaws.com",
+                "public_ip": "3.11.102.192",
+                "public_ipv4_pool": "amazon",
+                "tags": {},
+                "tags_all": {},
+                "timeouts": null,
+                "vpc": true
+              },
+              "sensitive_values": {
+                "tags": {},
+                "tags_all": {}
+              }
+            },
+            {
+              "address": "module.test-one.aws_eip_association.eip_jumpbox_eip_assoc",
+              "mode": "managed",
+              "type": "aws_eip_association",
+              "name": "eip_jumpbox_eip_assoc",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 0,
+              "values": {
+                "allocation_id": "eipalloc-0be32257e30139158",
+                "allow_reassociation": null,
+                "id": "eipassoc-09268cfd447837a84",
+                "instance_id": "i-08930acac0730f52a",
+                "network_interface_id": "eni-02544bb6156703420",
+                "private_ip_address": "172.1.100.64",
+                "public_ip": "3.11.102.192"
+              },
+              "sensitive_values": {},
+              "depends_on": [
+                "module.test-one.aws_eip.jumpbox_elastic_ip",
+                "module.test-one.aws_iam_instance_profile.assume_role_profile_jumpbox",
+                "module.test-one.aws_iam_role.assume_role_jumpbox",
+                "module.test-one.aws_instance.jumpbox",
+                "module.test-one.aws_security_group.jumpbox",
+                "module.test-one.data.aws_availability_zones.available",
+                "module.test-one.module.amp_terraform_test_vpc.aws_subnet.public",
+                "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+              ]
+            },
+            {
+              "address": "module.test-one.aws_iam_instance_profile.assume_role_profile_jumpbox",
+              "mode": "managed",
+              "type": "aws_iam_instance_profile",
+              "name": "assume_role_profile_jumpbox",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 0,
+              "values": {
+                "arn": "arn:aws:iam::304295633295:instance-profile/cra-assume-role-ec2-jumpbox",
+                "create_date": "2022-04-22T13:44:21Z",
+                "id": "cra-assume-role-ec2-jumpbox",
+                "name": "cra-assume-role-ec2-jumpbox",
+                "name_prefix": null,
+                "path": "/",
+                "role": "cra-assume-role-ssm-ec2-reporting",
+                "tags": {},
+                "tags_all": {
+                  "cloudsoft:group": "AMP",
+                  "cloudsoft:workload": "Terraform",
+                  "createdBy": "Juan",
+                  "environment": "dev"
+                },
+                "unique_id": "AIPAUNWLO4GH4FM3OBBLZ"
+              },
+              "sensitive_values": {
+                "tags": {},
+                "tags_all": {}
+              },
+              "depends_on": [
+                "module.test-one.aws_iam_role.assume_role_jumpbox"
+              ]
+            },
+            {
+              "address": "module.test-one.aws_iam_role.assume_role_jumpbox",
+              "mode": "managed",
+              "type": "aws_iam_role",
+              "name": "assume_role_jumpbox",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 0,
+              "values": {
+                "arn": "arn:aws:iam::304295633295:role/cra-assume-role-ssm-ec2-reporting",
+                "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                "create_date": "2022-04-22T13:44:20Z",
+                "description": "",
+                "force_detach_policies": false,
+                "id": "cra-assume-role-ssm-ec2-reporting",
+                "inline_policy": [
+                  {
+                    "name": "",
+                    "policy": ""
+                  }
+                ],
+                "managed_policy_arns": [],
+                "max_session_duration": 3600,
+                "name": "cra-assume-role-ssm-ec2-reporting",
+                "name_prefix": "",
+                "path": "/",
+                "permissions_boundary": null,
+                "tags": {},
+                "tags_all": {
+                  "cloudsoft:group": "AMP",
+                  "cloudsoft:workload": "Terraform",
+                  "createdBy": "Juan",
+                  "environment": "dev"
+                },
+                "unique_id": "AROAUNWLO4GHW7BCDHPXV"
+              },
+              "sensitive_values": {
+                "inline_policy": [
+                  {}
+                ],
+                "managed_policy_arns": [],
+                "tags": {},
+                "tags_all": {}
+              }
+            },
+            {
+              "address": "module.test-one.aws_instance.jumpbox",
+              "mode": "managed",
+              "type": "aws_instance",
+              "name": "jumpbox",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 1,
+              "values": {
+                "ami": "ami-0100b57d679daec93",
+                "arn": "arn:aws:ec2:eu-west-2:304295633295:instance/i-08930acac0730f52a",
+                "associate_public_ip_address": true,
+                "availability_zone": "eu-west-2a",
+                "capacity_reservation_specification": [
+                  {
+                    "capacity_reservation_preference": "open",
+                    "capacity_reservation_target": []
+                  }
+                ],
+                "cpu_core_count": 2,
+                "cpu_threads_per_core": 1,
+                "credit_specification": [],
+                "disable_api_termination": false,
+                "ebs_block_device": [],
+                "ebs_optimized": false,
+                "enclave_options": [
+                  {
+                    "enabled": false
+                  }
+                ],
+                "ephemeral_block_device": [],
+                "get_password_data": false,
+                "hibernation": false,
+                "host_id": null,
+                "iam_instance_profile": "cra-assume-role-ec2-jumpbox",
+                "id": "i-08930acac0730f52a",
+                "instance_initiated_shutdown_behavior": "stop",
+                "instance_state": "running",
+                "instance_type": "t4g.nano",
+                "ipv6_address_count": 0,
+                "ipv6_addresses": [],
+                "key_name": "redshift_dev",
+                "launch_template": [],
+                "metadata_options": [
+                  {
+                    "http_endpoint": "enabled",
+                    "http_put_response_hop_limit": 1,
+                    "http_tokens": "optional",
+                    "instance_metadata_tags": "disabled"
+                  }
+                ],
+                "monitoring": false,
+                "network_interface": [],
+                "outpost_arn": "",
+                "password_data": "",
+                "placement_group": "",
+                "placement_partition_number": null,
+                "primary_network_interface_id": "eni-02544bb6156703420",
+                "private_dns": "ip-172-1-100-64.eu-west-2.compute.internal",
+                "private_ip": "172.1.100.64",
+                "public_dns": "ec2-3-11-102-192.eu-west-2.compute.amazonaws.com",
+                "public_ip": "3.11.102.192",
+                "root_block_device": [
+                  {
+                    "delete_on_termination": true,
+                    "device_name": "/dev/sda1",
+                    "encrypted": false,
+                    "iops": 100,
+                    "kms_key_id": "",
+                    "tags": {},
+                    "throughput": 0,
+                    "volume_id": "vol-03635acc26756a9d1",
+                    "volume_size": 8,
+                    "volume_type": "gp2"
+                  }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "source_dest_check": true,
+                "subnet_id": "subnet-0d73e4aee85cc8c32",
+                "tags": {
+                  "Name": "AMP-Terraform tests jumpbox"
+                },
+                "tags_all": {
+                  "Name": "AMP-Terraform tests jumpbox",
+                  "cloudsoft:group": "AMP",
+                  "cloudsoft:workload": "Terraform",
+                  "createdBy": "Juan",
+                  "environment": "dev"
+                },
+                "tenancy": "default",
+                "timeouts": null,
+                "user_data": null,
+                "user_data_base64": null,
+                "volume_tags": null,
+                "vpc_security_group_ids": [
+                  "sg-0ef182bc7a67c3cb6"
+                ]
+              },
+              "sensitive_values": {
+                "capacity_reservation_specification": [
+                  {
+                    "capacity_reservation_target": []
+                  }
+                ],
+                "credit_specification": [],
+                "ebs_block_device": [],
+                "enclave_options": [
+                  {}
+                ],
+                "ephemeral_block_device": [],
+                "ipv6_addresses": [],
+                "launch_template": [],
+                "metadata_options": [
+                  {}
+                ],
+                "network_interface": [],
+                "root_block_device": [
+                  {
+                    "tags": {}
+                  }
+                ],
+                "secondary_private_ips": [],
+                "security_groups": [],
+                "tags": {},
+                "tags_all": {},
+                "vpc_security_group_ids": [
+                  false
+                ]
+              },
+              "depends_on": [
+                "module.test-one.aws_iam_instance_profile.assume_role_profile_jumpbox",
+                "module.test-one.aws_iam_role.assume_role_jumpbox",
+                "module.test-one.aws_security_group.jumpbox",
+                "module.test-one.data.aws_availability_zones.available",
+                "module.test-one.module.amp_terraform_test_vpc.aws_subnet.public",
+                "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+              ]
+            },
+            {
+              "address": "module.test-one.aws_key_pair.deployer",
+              "mode": "managed",
+              "type": "aws_key_pair",
+              "name": "deployer",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 1,
+              "values": {
+                "arn": "arn:aws:ec2:eu-west-2:304295633295:key-pair/redshift_dev",
+                "fingerprint": "59:ff:68:5a:54:59:94:2e:40:c2:7d:30:df:ff:fa:8e",
+                "id": "redshift_dev",
+                "key_name": "redshift_dev",
+                "key_name_prefix": "",
+                "key_pair_id": "key-07caaf08a85fc123b",
+                "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj6RQDSmJpxKCRx0UPSIrSoGv2711cEocOgBxuIcAT2xIf1qlbUF8vOAnL0I6YHK2qvyEyMchtNpLlZWYB29y7XhDbVn59i6JupKWCtQ7jTVBce8anyJzoyVxsCDJLHepD0aVikisF359XtONs1SrLYKNjaqZjin3+ZT3sxkaqqgm/8U0oQsTx3jMa02J/bW4kg+B5rjvlIqCrXVetVnq8dwti1NJPIcUbrtpDlstbDIlJWBQNcSwOIrLaHkZ6WKiyFDYlur5bhqGXuXlDyq/CHgiDfMxAd2/NxDLTvuqZ8Qyt1L9ISuOIRKK4Sf1l9WIhIZWhbJyL0eYDgk6t6+FJ7Rpf5eRUhsBa7JJoaBd2A6on8soPwPChDmcNkDl6Il3x6rHxbi2LnrZuDWsFImXxp8dcodhCuRIyEjw4B9ygGWpO8HMyVNGzQfz1VR93GZ6204xJOTcT1J+zkUMtDN0iOhbGCF3Ni9dw0K/dfTEYPgvK8QFDoyvUg00VrO7bJrk= juan@MacBrerizo.local",
+                "tags": {},
+                "tags_all": {
+                  "cloudsoft:group": "AMP",
+                  "cloudsoft:workload": "Terraform",
+                  "createdBy": "Juan",
+                  "environment": "dev"
+                }
+              },
+              "sensitive_values": {
+                "tags": {},
+                "tags_all": {}
+              }
+            },
+            {
+              "address": "module.test-one.aws_security_group.jumpbox",
+              "mode": "managed",
+              "type": "aws_security_group",
+              "name": "jumpbox",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 1,
+              "values": {
+                "arn": "arn:aws:ec2:eu-west-2:304295633295:security-group/sg-0ef182bc7a67c3cb6",
+                "description": "Managed by Terraform",
+                "egress": [
+                  {
+                    "cidr_blocks": [
+                      "0.0.0.0/0"
+                    ],
+                    "description": "",
+                    "from_port": 443,
+                    "ipv6_cidr_blocks": [],
+                    "prefix_list_ids": [],
+                    "protocol": "tcp",
+                    "security_groups": [],
+                    "self": false,
+                    "to_port": 443
+                  }
+                ],
+                "id": "sg-0ef182bc7a67c3cb6",
+                "ingress": [
+                  {
+                    "cidr_blocks": [
+                      "35.178.122.71/32"
+                    ],
+                    "description": "",
+                    "from_port": 22,
+                    "ipv6_cidr_blocks": [],
+                    "prefix_list_ids": [],
+                    "protocol": "tcp",
+                    "security_groups": [],
+                    "self": false,
+                    "to_port": 22
+                  }
+                ],
+                "name": "jumpbox",
+                "name_prefix": "",
+                "owner_id": "304295633295",
+                "revoke_rules_on_delete": false,
+                "tags": {},
+                "tags_all": {
+                  "cloudsoft:group": "AMP",
+                  "cloudsoft:workload": "Terraform",
+                  "createdBy": "Juan",
+                  "environment": "dev"
+                },
+                "timeouts": null,
+                "vpc_id": "vpc-03f9a80780233d181"
+              },
+              "sensitive_values": {
+                "egress": [
+                  {
+                    "cidr_blocks": [
+                      false
+                    ],
+                    "ipv6_cidr_blocks": [],
+                    "prefix_list_ids": [],
+                    "security_groups": []
+                  }
+                ],
+                "ingress": [
+                  {
+                    "cidr_blocks": [
+                      false
+                    ],
+                    "ipv6_cidr_blocks": [],
+                    "prefix_list_ids": [],
+                    "security_groups": []
+                  }
+                ],
+                "tags": {},
+                "tags_all": {}
+              },
+              "depends_on": [
+                "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this"
+              ]
+            },
+            {
+              "address": "module.test-one.data.aws_availability_zones.available",
+              "mode": "data",
+              "type": "aws_availability_zones",
+              "name": "available",
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 0,
+              "values": {
+                "all_availability_zones": null,
+                "exclude_names": null,
+                "exclude_zone_ids": null,
+                "filter": null,
+                "group_names": [
+                  "eu-west-2"
+                ],
+                "id": "eu-west-2",
+                "names": [
+                  "eu-west-2a",
+                  "eu-west-2b",
+                  "eu-west-2c"
+                ],
+                "state": null,
+                "zone_ids": [
+                  "euw2-az2",
+                  "euw2-az3",
+                  "euw2-az1"
+                ]
+              },
+              "sensitive_values": {
+                "group_names": [
+                  false
+                ],
+                "names": [
+                  false,
+                  false,
+                  false
+                ],
+                "zone_ids": [
+                  false,
+                  false,
+                  false
+                ]
+              }
+            }
+          ],
+          "address": "module.test-one",
+          "child_modules": [
+            {
+              "resources": [
+                  {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_eip.nat[0]",
+                  "mode": "managed",
+                  "type": "aws_eip",
+                  "name": "nat",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "address": null,
+                    "allocation_id": "eipalloc-035a3bbc4dfc513f0",
+                    "associate_with_private_ip": null,
+                    "association_id": "eipassoc-005613d46b431123b",
+                    "carrier_ip": "",
+                    "customer_owned_ip": "",
+                    "customer_owned_ipv4_pool": "",
+                    "domain": "vpc",
+                    "id": "eipalloc-035a3bbc4dfc513f0",
+                    "instance": "",
+                    "network_border_group": "eu-west-2",
+                    "network_interface": "eni-0bbdd359a590b2d0c",
+                    "private_dns": "ip-172-1-100-30.eu-west-2.compute.internal",
+                    "private_ip": "172.1.100.30",
+                    "public_dns": "ec2-52-56-207-41.eu-west-2.compute.amazonaws.com",
+                    "public_ip": "52.56.207.41",
+                    "public_ipv4_pool": "amazon",
+                    "tags": {
+                      "Name": "amp-terraform-test-vpc-eu-west-2a"
+                    },
+                    "tags_all": {
+                      "Name": "amp-terraform-test-vpc-eu-west-2a",
+                      "cloudsoft:group": "AMP",
+                      "cloudsoft:workload": "Terraform",
+                      "createdBy": "Juan",
+                      "environment": "dev"
+                    },
+                    "timeouts": null,
+                    "vpc": true
+                  },
+                  "sensitive_values": {
+                    "tags": {},
+                    "tags_all": {}
+                  },
+                  "depends_on": [
+                    "module.test-one.data.aws_availability_zones.available"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_internet_gateway.this[0]",
+                  "mode": "managed",
+                  "type": "aws_internet_gateway",
+                  "name": "this",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "arn": "arn:aws:ec2:eu-west-2:304295633295:internet-gateway/igw-02f9aab87c19ea96a",
+                    "id": "igw-02f9aab87c19ea96a",
+                    "owner_id": "304295633295",
+                    "tags": {
+                      "Name": "amp-terraform-test-vpc"
+                    },
+                    "tags_all": {
+                      "Name": "amp-terraform-test-vpc",
+                      "cloudsoft:group": "AMP",
+                      "cloudsoft:workload": "Terraform",
+                      "createdBy": "Juan",
+                      "environment": "dev"
+                    },
+                    "vpc_id": "vpc-03f9a80780233d181"
+                  },
+                  "sensitive_values": {
+                    "tags": {},
+                    "tags_all": {}
+                  },
+                  "depends_on": [
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_nat_gateway.this[0]",
+                  "mode": "managed",
+                  "type": "aws_nat_gateway",
+                  "name": "this",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "allocation_id": "eipalloc-035a3bbc4dfc513f0",
+                    "connectivity_type": "public",
+                    "id": "nat-09c76e845b9da6896",
+                    "network_interface_id": "eni-0bbdd359a590b2d0c",
+                    "private_ip": "172.1.100.30",
+                    "public_ip": "52.56.207.41",
+                    "subnet_id": "subnet-0d73e4aee85cc8c32",
+                    "tags": {
+                      "Name": "amp-terraform-test-vpc-eu-west-2a"
+                    },
+                    "tags_all": {
+                      "Name": "amp-terraform-test-vpc-eu-west-2a",
+                      "cloudsoft:group": "AMP",
+                      "cloudsoft:workload": "Terraform",
+                      "createdBy": "Juan",
+                      "environment": "dev"
+                    }
+                  },
+                  "sensitive_values": {
+                    "tags": {},
+                    "tags_all": {}
+                  },
+                  "depends_on": [
+                    "module.test-one.data.aws_availability_zones.available",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_eip.nat",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_internet_gateway.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_subnet.public",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_route.private_nat_gateway[0]",
+                  "mode": "managed",
+                  "type": "aws_route",
+                  "name": "private_nat_gateway",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "carrier_gateway_id": "",
+                    "destination_cidr_block": "0.0.0.0/0",
+                    "destination_ipv6_cidr_block": "",
+                    "destination_prefix_list_id": "",
+                    "egress_only_gateway_id": "",
+                    "gateway_id": "",
+                    "id": "r-rtb-0fb963b5e1391cc211080289494",
+                    "instance_id": "",
+                    "instance_owner_id": "",
+                    "local_gateway_id": "",
+                    "nat_gateway_id": "nat-09c76e845b9da6896",
+                    "network_interface_id": "",
+                    "origin": "CreateRoute",
+                    "route_table_id": "rtb-0fb963b5e1391cc21",
+                    "state": "active",
+                    "timeouts": {
+                      "create": "5m",
+                      "delete": null,
+                      "update": null
+                    },
+                    "transit_gateway_id": "",
+                    "vpc_endpoint_id": "",
+                    "vpc_peering_connection_id": ""
+                  },
+                  "sensitive_values": {
+                    "timeouts": {}
+                  },
+                  "depends_on": [
+                    "module.test-one.data.aws_availability_zones.available",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_eip.nat",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_internet_gateway.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_nat_gateway.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_route_table.private",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_subnet.public",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_route.public_internet_gateway[0]",
+                  "mode": "managed",
+                  "type": "aws_route",
+                  "name": "public_internet_gateway",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "carrier_gateway_id": "",
+                    "destination_cidr_block": "0.0.0.0/0",
+                    "destination_ipv6_cidr_block": "",
+                    "destination_prefix_list_id": "",
+                    "egress_only_gateway_id": "",
+                    "gateway_id": "igw-02f9aab87c19ea96a",
+                    "id": "r-rtb-0a44ff6df7da85a871080289494",
+                    "instance_id": "",
+                    "instance_owner_id": "",
+                    "local_gateway_id": "",
+                    "nat_gateway_id": "",
+                    "network_interface_id": "",
+                    "origin": "CreateRoute",
+                    "route_table_id": "rtb-0a44ff6df7da85a87",
+                    "state": "active",
+                    "timeouts": {
+                      "create": "5m",
+                      "delete": null,
+                      "update": null
+                    },
+                    "transit_gateway_id": "",
+                    "vpc_endpoint_id": "",
+                    "vpc_peering_connection_id": ""
+                  },
+                  "sensitive_values": {
+                    "timeouts": {}
+                  },
+                  "depends_on": [
+                    "module.test-one.module.amp_terraform_test_vpc.aws_internet_gateway.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_route_table.public",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_route_table.private[0]",
+                  "mode": "managed",
+                  "type": "aws_route_table",
+                  "name": "private",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "arn": "arn:aws:ec2:eu-west-2:304295633295:route-table/rtb-0fb963b5e1391cc21",
+                    "id": "rtb-0fb963b5e1391cc21",
+                    "owner_id": "304295633295",
+                    "propagating_vgws": [],
+                    "route": [
+                      {
+                        "carrier_gateway_id": "",
+                        "cidr_block": "0.0.0.0/0",
+                        "destination_prefix_list_id": "",
+                        "egress_only_gateway_id": "",
+                        "gateway_id": "",
+                        "instance_id": "",
+                        "ipv6_cidr_block": "",
+                        "local_gateway_id": "",
+                        "nat_gateway_id": "nat-09c76e845b9da6896",
+                        "network_interface_id": "",
+                        "transit_gateway_id": "",
+                        "vpc_endpoint_id": "",
+                        "vpc_peering_connection_id": ""
+                      }
+                    ],
+                    "tags": {
+                      "Name": "amp-terraform-test-vpc-private-eu-west-2a"
+                    },
+                    "tags_all": {
+                      "Name": "amp-terraform-test-vpc-private-eu-west-2a",
+                      "cloudsoft:group": "AMP",
+                      "cloudsoft:workload": "Terraform",
+                      "createdBy": "Juan",
+                      "environment": "dev"
+                    },
+                    "timeouts": null,
+                    "vpc_id": "vpc-03f9a80780233d181"
+                  },
+                  "sensitive_values": {
+                    "propagating_vgws": [],
+                    "route": [
+                      {}
+                    ],
+                    "tags": {},
+                    "tags_all": {}
+                  },
+                  "depends_on": [
+                    "module.test-one.data.aws_availability_zones.available",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_route_table.public[0]",
+                  "mode": "managed",
+                  "type": "aws_route_table",
+                  "name": "public",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "arn": "arn:aws:ec2:eu-west-2:304295633295:route-table/rtb-0a44ff6df7da85a87",
+                    "id": "rtb-0a44ff6df7da85a87",
+                    "owner_id": "304295633295",
+                    "propagating_vgws": [],
+                    "route": [
+                      {
+                        "carrier_gateway_id": "",
+                        "cidr_block": "0.0.0.0/0",
+                        "destination_prefix_list_id": "",
+                        "egress_only_gateway_id": "",
+                        "gateway_id": "igw-02f9aab87c19ea96a",
+                        "instance_id": "",
+                        "ipv6_cidr_block": "",
+                        "local_gateway_id": "",
+                        "nat_gateway_id": "",
+                        "network_interface_id": "",
+                        "transit_gateway_id": "",
+                        "vpc_endpoint_id": "",
+                        "vpc_peering_connection_id": ""
+                      }
+                    ],
+                    "tags": {
+                      "Name": "amp-terraform-test-vpc-public"
+                    },
+                    "tags_all": {
+                      "Name": "amp-terraform-test-vpc-public",
+                      "cloudsoft:group": "AMP",
+                      "cloudsoft:workload": "Terraform",
+                      "createdBy": "Juan",
+                      "environment": "dev"
+                    },
+                    "timeouts": null,
+                    "vpc_id": "vpc-03f9a80780233d181"
+                  },
+                  "sensitive_values": {
+                    "propagating_vgws": [],
+                    "route": [
+                      {}
+                    ],
+                    "tags": {},
+                    "tags_all": {}
+                  },
+                  "depends_on": [
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_route_table_association.private[0]",
+                  "mode": "managed",
+                  "type": "aws_route_table_association",
+                  "name": "private",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "gateway_id": "",
+                    "id": "rtbassoc-056feb264562c7756",
+                    "route_table_id": "rtb-0fb963b5e1391cc21",
+                    "subnet_id": "subnet-0eb961ec4eb3ddbef"
+                  },
+                  "sensitive_values": {},
+                  "depends_on": [
+                    "module.test-one.data.aws_availability_zones.available",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_route_table.private",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_subnet.private",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_route_table_association.public[0]",
+                  "mode": "managed",
+                  "type": "aws_route_table_association",
+                  "name": "public",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 0,
+                  "values": {
+                    "gateway_id": "",
+                    "id": "rtbassoc-0f7586a0440a980a7",
+                    "route_table_id": "rtb-0a44ff6df7da85a87",
+                    "subnet_id": "subnet-0d73e4aee85cc8c32"
+                  },
+                  "sensitive_values": {},
+                  "depends_on": [
+                    "module.test-one.data.aws_availability_zones.available",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_route_table.public",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_subnet.public",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_subnet.private[0]",
+                  "mode": "managed",
+                  "type": "aws_subnet",
+                  "name": "private",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 1,
+                  "values": {
+                    "arn": "arn:aws:ec2:eu-west-2:304295633295:subnet/subnet-0eb961ec4eb3ddbef",
+                    "assign_ipv6_address_on_creation": false,
+                    "availability_zone": "eu-west-2a",
+                    "availability_zone_id": "euw2-az2",
+                    "cidr_block": "172.1.0.0/24",
+                    "customer_owned_ipv4_pool": "",
+                    "enable_dns64": false,
+                    "enable_resource_name_dns_a_record_on_launch": false,
+                    "enable_resource_name_dns_aaaa_record_on_launch": false,
+                    "id": "subnet-0eb961ec4eb3ddbef",
+                    "ipv6_cidr_block": "",
+                    "ipv6_cidr_block_association_id": "",
+                    "ipv6_native": false,
+                    "map_customer_owned_ip_on_launch": false,
+                    "map_public_ip_on_launch": false,
+                    "outpost_arn": "",
+                    "owner_id": "304295633295",
+                    "private_dns_hostname_type_on_launch": "ip-name",
+                    "tags": {
+                      "Name": "amp-terraform-test-vpc-private-eu-west-2a"
+                    },
+                    "tags_all": {
+                      "Name": "amp-terraform-test-vpc-private-eu-west-2a",
+                      "cloudsoft:group": "AMP",
+                      "cloudsoft:workload": "Terraform",
+                      "createdBy": "Juan",
+                      "environment": "dev"
+                    },
+                    "timeouts": null,
+                    "vpc_id": "vpc-03f9a80780233d181"
+                  },
+                  "sensitive_values": {
+                    "tags": {},
+                    "tags_all": {}
+                  },
+                  "depends_on": [
+                    "module.test-one.data.aws_availability_zones.available",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_subnet.public[0]",
+                  "mode": "managed",
+                  "type": "aws_subnet",
+                  "name": "public",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 1,
+                  "values": {
+                    "arn": "arn:aws:ec2:eu-west-2:304295633295:subnet/subnet-0d73e4aee85cc8c32",
+                    "assign_ipv6_address_on_creation": false,
+                    "availability_zone": "eu-west-2a",
+                    "availability_zone_id": "euw2-az2",
+                    "cidr_block": "172.1.100.0/24",
+                    "customer_owned_ipv4_pool": "",
+                    "enable_dns64": false,
+                    "enable_resource_name_dns_a_record_on_launch": false,
+                    "enable_resource_name_dns_aaaa_record_on_launch": false,
+                    "id": "subnet-0d73e4aee85cc8c32",
+                    "ipv6_cidr_block": "",
+                    "ipv6_cidr_block_association_id": "",
+                    "ipv6_native": false,
+                    "map_customer_owned_ip_on_launch": false,
+                    "map_public_ip_on_launch": true,
+                    "outpost_arn": "",
+                    "owner_id": "304295633295",
+                    "private_dns_hostname_type_on_launch": "ip-name",
+                    "tags": {
+                      "Name": "amp-terraform-test-vpc-public-eu-west-2a"
+                    },
+                    "tags_all": {
+                      "Name": "amp-terraform-test-vpc-public-eu-west-2a",
+                      "cloudsoft:group": "AMP",
+                      "cloudsoft:workload": "Terraform",
+                      "createdBy": "Juan",
+                      "environment": "dev"
+                    },
+                    "timeouts": null,
+                    "vpc_id": "vpc-03f9a80780233d181"
+                  },
+                  "sensitive_values": {
+                    "tags": {},
+                    "tags_all": {}
+                  },
+                  "depends_on": [
+                    "module.test-one.data.aws_availability_zones.available",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this",
+                    "module.test-one.module.amp_terraform_test_vpc.aws_vpc_ipv4_cidr_block_association.this"
+                  ]
+                },
+                {
+                  "address": "module.test-one.module.amp_terraform_test_vpc.aws_vpc.this[0]",
+                  "mode": "managed",
+                  "type": "aws_vpc",
+                  "name": "this",
+                  "index": 0,
+                  "provider_name": "registry.terraform.io/hashicorp/aws",
+                  "schema_version": 1,
+                  "values": {
+                    "arn": "arn:aws:ec2:eu-west-2:304295633295:vpc/vpc-03f9a80780233d181",
+                    "assign_generated_ipv6_cidr_block": false,
+                    "cidr_block": "172.1.0.0/16",
+                    "default_network_acl_id": "acl-0ae2136facb49b6cf",
+                    "default_route_table_id": "rtb-049671814eb5bde7c",
+                    "default_security_group_id": "sg-0119be9e845356563",
+                    "dhcp_options_id": "dopt-f99d7e90",
+                    "enable_classiclink": false,
+                    "enable_classiclink_dns_support": false,
+                    "enable_dns_hostnames": true,
+                    "enable_dns_support": true,
+                    "id": "vpc-03f9a80780233d181",
+                    "instance_tenancy": "default",
+                    "ipv4_ipam_pool_id": null,
+                    "ipv4_netmask_length": null,
+                    "ipv6_association_id": "",
+                    "ipv6_cidr_block": "",
+                    "ipv6_cidr_block_network_border_group": "",
+                    "ipv6_ipam_pool_id": "",
+                    "ipv6_netmask_length": 0,
+                    "main_route_table_id": "rtb-049671814eb5bde7c",
+                    "owner_id": "304295633295",
+                    "tags": {
+                      "Name": "amp-terraform-test-vpc"
+                    },
+                    "tags_all": {
+                      "Name": "amp-terraform-test-vpc",
+                      "cloudsoft:group": "AMP",
+                      "cloudsoft:workload": "Terraform",
+                      "createdBy": "Juan",
+                      "environment": "dev"
+                    }
+                  },
+                  "sensitive_values": {
+                    "tags": {},
+                    "tags_all": {}
+                  }
+                }
+              ],
+              "address": "module.test-one.module.amp_terraform_test_vpc"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
It allow to choose the working dir for the environment to deploy. It works for ZIP applications. If the environment to deploy has a reference to a module also defined in the same file, it will represent the resources configured in the module.

todo:
* [ ] Control the working dir validated and the errors are correctly shown
* [ ] Tidy the code
* [ ] Write some documentation about it use and the architecture used for define the file structure