### PR TITLE
Local terraform

### DIFF
--- a/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
+++ b/src/main/java/io/cloudsoft/terraform/TerraformConfiguration.java
@@ -70,10 +70,24 @@ public interface TerraformConfiguration extends SoftwareProcess {
             .description("URL of the file containing values for the Terraform variables.")
             .build();
 
+    @SetFromFlag("tfPath")
+    ConfigKey<String> TERRAFORM_PATH = ConfigKeys.builder(String.class)
+            .name("tf.path")
+            .description("Path to the Terraform executable")
+            .defaultValue("")
+            .build();
+    @SetFromFlag("tfSearch")
+    ConfigKey<Boolean> LOOK_FOR_TERRAFORM_INSTALLED = ConfigKeys.builder(Boolean.class)
+            .name("tf.search")
+            .description("Allow to look for the terraform binary in the system if not fount in explicit path" +
+                    " (`" + TERRAFORM_PATH.getName() + "` config key) or the property wasn't supplied")
+            .defaultValue(false)
+            .build();
+
     AttributeSensor<String> CONFIGURATION_APPLIED = Sensors.newStringSensor("tf.configuration.applied",
             "The most recent time a Terraform configuration has been successfully applied.");
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     AttributeSensor<Map<String, Object>> PLAN = new BasicAttributeSensor(Map.class, "tf.plan",
             "The contents of the Terraform plan command which specifies exactly what actions will be taken upon applying the configuration.");
 


### PR DESCRIPTION
Avoid to download Terraform from the internet by passing path or allowing AMP to try to find it on the system

Blueprint for testing, see commented lines for `tf.path` and `tf.seatch`:
```yaml
location: localhost
name: AMP Terraform Security Group deployment
services:
  - type: terraform
    name: Terraform Configuration
    brooklyn.config:
      # tf.path: "/opt/homebrew/bin/terraform"
      # tf.search: true
      shell.env:
        AWS_ACCESS_KEY_ID: "x"
        AWS_SECRET_ACCESS_KEY: "xxx"
        AWS_SESSION_TOKEN: "xxx"
      tf.configuration.contents: |
        provider "aws" {
            region = "eu-west-2"
            default_tags {
                tags = {
                    environment = "dev",
                    "cloudsoft:group"	= "AMP",
                    "cloudsoft:workload"	= "Terraform"
                }
            }
        }
        resource "aws_security_group" "allow_all" {
          description = "test-security-group allowing all access"
          ingress {
            from_port = 0
            to_port = 0
            protocol = "-1"
            cidr_blocks = ["0.0.0.0/0"]
          }
          egress {
            from_port = 0
            to_port = 0
            protocol = "-1"
            cidr_blocks = ["0.0.0.0/0"]
          }
          tags = {
            Name = "TestSG-KillMePlease"
          }
        }
        output "name" {
            value = "${aws_security_group.allow_all.name}"
        }
        output "id" {
            value = "${aws_security_group.allow_all.id}"
        }
```