### PR TITLE
Restores old predicate class for rebind

### DIFF
--- a/src/main/java/io/cloudsoft/terraform/predicates/TerraformDiscoveryPredicates.java
+++ b/src/main/java/io/cloudsoft/terraform/predicates/TerraformDiscoveryPredicates.java
@@ -1,0 +1,11 @@
+package io.cloudsoft.terraform.predicates;
+
+import com.google.common.base.Predicate;
+import org.apache.brooklyn.api.entity.Entity;
+
+public class TerraformDiscoveryPredicates {
+    /** Included for rebind support. */
+    public static Predicate<Entity> sensorMatches(final String sensorName, final String sensorValueRegex) {
+        return SensorMatches.sensorMatches(sensorName, sensorValueRegex);
+    }
+}


### PR DESCRIPTION
Fixes rebind issue caused by changing predicate classname.

See [#182071973](https://www.pivotaltracker.com/story/show/182071973)

Signed-off-by: Andrew Donald Kennedy <andrew.international@gmail.com>